### PR TITLE
Alterando pasta do Bootstrap e adicionando dependências no Yarn e NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "author": "frontend2 <frontend2gv8@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "bower": "^1.7.9",
+    "bootstrap": "^4.0.0",
+    "bower": "^1.8.2",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.1",
     "gulp-clean": "^0.3.2",
@@ -32,7 +33,9 @@
     "imagemin-pngquant": "^5.0.0",
     "imagemin-svgo": "^5.2.0",
     "imagemin-webp": "^4.0.0",
+    "jquery": "^1.9.1",
     "node-sprite-generator": "^0.10.2",
-    "path": "^0.12.7"
+    "path": "^0.12.7",
+    "popper.js": "^1.12.9"
   }
 }

--- a/source/styles/components/vendor/_external-imports.scss
+++ b/source/styles/components/vendor/_external-imports.scss
@@ -40,5 +40,5 @@ $screen-xs-max:              ($screen-sm-min - 1) !default;
 $screen-sm-max:              ($screen-md-min - 1) !default;
 $screen-md-max:              ($screen-lg-min - 1) !default;
 
-@import "../../../../bower_components/bootstrap/scss/bootstrap.scss";
+@import "../../../../node_modules/bootstrap/scss/bootstrap.scss";
 @import "../../../../bower_components/font-awesome/scss/font-awesome.scss";

--- a/yarn.lock
+++ b/yarn.lock
@@ -288,9 +288,13 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bower@^1.7.9:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/bower/-/bower-1.8.0.tgz#55dbebef0ad9155382d9e9d3e497c1372345b44a"
+bootstrap@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0.tgz#ceb03842c145fcc1b9b4e15da2a05656ba68469a"
+
+bower@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/bower/-/bower-1.8.2.tgz#adf53529c8d4af02ef24fb8d5341c1419d33e2f7"
 
 brace-expansion@^1.0.0:
   version "1.1.7"
@@ -2156,6 +2160,10 @@ jpegoptim-bin@^3.0.0:
     bin-wrapper "^3.0.0"
     logalot "^2.0.0"
 
+jquery@^1.9.1:
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.12.4.tgz#01e1dfba290fe73deba77ceeacb0f9ba2fec9e0c"
+
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
@@ -3098,6 +3106,10 @@ pngquant-bin@^3.0.0:
     bin-build "^2.0.0"
     bin-wrapper "^3.0.0"
     logalot "^2.0.0"
+
+popper.js@^1.12.9:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.13.0.tgz#e1e7ff65cc43f7cf9cf16f1510a75e81f84f4565"
 
 postcss-load-config@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Pelo fato de o Bower ter sido depreciado nessa última versão do Bootstrap, adicionei as dependências do Bootstrap no NPM e no Yarn, e alterei a chamada do bootstrap.scss